### PR TITLE
Exit 1 when assertion failed

### DIFF
--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -7,11 +7,19 @@ class Puppet::Application::Spec < Puppet::Application
   include Puppet::Util::Colors
 
   def run_command
+    output = Hash.new
+
     begin
       Puppet::Test::TestHelper.initialize
-      process_spec_directory(specdir)
+      output = process_spec_directory(specdir)
     rescue Exception => e
       print colorize(:red, "#{e.message}\n")
+      exit 1
+    end
+
+    if output[:failed] == 0
+      exit 0
+    else
       exit 1
     end
   end
@@ -20,6 +28,7 @@ class Puppet::Application::Spec < Puppet::Application
     results = Dir.glob("#{specdir}/**/*_spec.pp").map { |spec| process_spec(spec) }.flatten
     output = visit_assertions(results)
     print_results(output)
+    output
   end
 
   def process_spec(path)

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -18,8 +18,8 @@ class Puppet::Application::Spec < Puppet::Application
 
   def process_spec_directory(specdir)
     results = Dir.glob("#{specdir}/**/*_spec.pp").map { |spec| process_spec(spec) }.flatten
-    print "\n\n"
-    print visit_assertions(results)
+    output = visit_assertions(results)
+    print_results(output)
   end
 
   def process_spec(path)
@@ -51,8 +51,8 @@ class Puppet::Application::Spec < Puppet::Application
     catalog
   end
 
-  # Return a string that contains
-  # output to be displayed to the
+  # Return a hash that contains
+  # data to be displayed to the
   # user which represents the results
   # of the assertions.
   def visit_assertions(assertions)
@@ -73,11 +73,26 @@ class Puppet::Application::Spec < Puppet::Application
       end
     end
 
-    footer = "Evaluated #{count} assertion"
-    footer += "s" unless count == 1
-    msg.push(colorize(:yellow, "#{footer}\n"))
-    
-    msg.join
+    {
+      :msg    => msg.join,
+      :count  => count,
+      :failed => failed_count,
+    }
+  end
+
+  # Given the resulting hash
+  # from .visit_assertions,
+  # present the output to the
+  # user.
+  def print_results(results)
+    print "\n\n"
+    print results[:msg] if results[:msg]
+
+    if results[:count] == 1
+      print colorize(:yellow, "Evaluated #{results[:count]} assertion\n")
+    else
+      print colorize(:yellow, "Evaluated #{results[:count]} assertions\n")
+    end
   end
 
   # Validate assertion raises an error

--- a/spec/integration/application/spec_spec.rb
+++ b/spec/integration/application/spec_spec.rb
@@ -2,20 +2,6 @@ require 'puppetlabs_spec_helper/module_spec_helper'
 require 'puppet/application/spec'
 
 describe Puppet::Application::Spec do
-  describe ".process_spec_directory" do
-    context "when no specs are found" do
-      before do
-        Dir.stubs(:glob).returns([])
-      end
-
-      it "should print the expected output" do
-        STDOUT.expects(:write).once.with("\n\n")
-        STDOUT.expects(:write).once.with("\e[0;33mEvaluated 0 assertions\n\e[0m")
-        subject.run_command
-      end
-    end
-  end
-
   describe ".visit_assertions" do
     context "with a single passing assertion" do
       let(:the_assertions) {[
@@ -31,9 +17,11 @@ describe Puppet::Application::Spec do
       ]}
 
       it "should return the expected output" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n\e[0;33mEvaluated 1 assertion\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count  => 1,
+          :failed => 1,
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
+        })
       end
     end
 
@@ -51,9 +39,11 @@ describe Puppet::Application::Spec do
       ]}
 
       it "should return the expected output" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n\e[0;33mEvaluated 1 assertion\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count  => 1,
+          :failed => 1,
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
+        })
       end
     end
 
@@ -104,9 +94,11 @@ describe Puppet::Application::Spec do
       ]}
 
       it "should raise an error" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;33mEvaluated 1 assertion\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count  => 1,
+          :failed => 0,
+          :msg    => "",
+        })
       end
     end
 

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -62,7 +62,7 @@ describe Puppet::Application::Spec do
       subject.stubs(:process_spec).with(:stub_spec2).returns(:stub_result2)
       subject.stubs(:process_spec).with(:stub_spec3).returns([:stub_result3])
       subject.stubs(:visit_assertions).returns(:stub_results)
-      subject.stubs(:print)
+      subject.stubs(:print_results)
       Dir.stubs(:glob).returns(the_files)
     end
 
@@ -86,8 +86,7 @@ describe Puppet::Application::Spec do
     end
 
     it "should print the results" do
-      subject.expects(:print).once.with("\n\n")
-      subject.expects(:print).once.with(:stub_results)
+      subject.expects(:print_results).once.with(:stub_results)
       subject.process_spec_directory('stub_path')
     end
   end
@@ -205,9 +204,11 @@ describe Puppet::Application::Spec do
         }
       ]}
       it "should return the expected output" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;33mEvaluated 1 assertion\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count  => 1,
+          :failed => 0,
+          :msg    => "",
+        })
       end
     end
 
@@ -231,9 +232,11 @@ describe Puppet::Application::Spec do
         }
       ]}
       it "should return the expected output" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;33mEvaluated 2 assertions\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count  => 2,
+          :failed => 0,
+          :msg    => "",
+        })
       end
       it "should validate each assertion" do
         subject.expects(:validate_assertion).with(the_assertions[0])
@@ -261,9 +264,11 @@ describe Puppet::Application::Spec do
         }
       ]}
       it "should return the expected output" do
-        expect(subject.visit_assertions(the_assertions)).to eq(
-          "\e[0;31m1) Assertion stub_name_2 failed on {\"stub_attribute_2\"=>\"not the expectation\"}\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the expectation'\n\n\e[0;33mEvaluated 2 assertions\n\e[0m"
-        )
+        expect(subject.visit_assertions(the_assertions)).to eq({
+          :count => 2,
+          :failed => 1,
+          :msg => "\e[0;31m1) Assertion stub_name_2 failed on {\"stub_attribute_2\"=>\"not the expectation\"}\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the expectation'\n\n",
+        })
       end
     end
   end
@@ -296,6 +301,71 @@ describe Puppet::Application::Spec do
         expect{subject.validate_assertion(the_assertion)}.to_not raise_error
       end
     end
+  end
+
+  describe ".print_results" do
+    let(:the_results) {{}}
+
+    before do
+      subject.stubs(:print)
+    end
+
+    it "should print two newlines" do
+      subject.expects(:print).once.with("\n\n")
+      subject.print_results(the_results)
+    end
+
+    context "when given a hash with a message" do
+      let(:the_results) {{
+        :msg => "stub message",
+      }}
+
+      it "should print the message" do
+        subject.expects(:print).once.with("stub message")
+        subject.print_results(the_results)
+      end
+    end
+
+    context "when given a hash with no message" do
+      it "should not print the message" do
+        subject.expects(:print).once.with("stub message").never
+        subject.print_results(the_results)
+      end
+    end
+
+    context "when given a hash with one resource" do
+      let(:the_results) {{
+        :count => 1
+      }}
+
+      it "should print a singular footer message" do
+        subject.expects(:print).with("\e[0;33mEvaluated 1 assertion\n\e[0m")
+        subject.print_results(the_results)
+      end
+    end
+
+    context "when given a hash with two resources" do
+      let(:the_results) {{
+        :count => 2
+      }}
+
+      it "should print a plural footer message" do
+        subject.expects(:print).with("\e[0;33mEvaluated 2 assertions\n\e[0m")
+        subject.print_results(the_results)
+      end
+    end
+
+    context "when given a hash with no resources" do
+      let(:the_results) {{
+        :count => 0
+      }}
+
+      it "should print a plural footer message" do
+        subject.expects(:print).with("\e[0;33mEvaluated 0 assertions\n\e[0m")
+        subject.print_results(the_results)
+      end
+    end
+
   end
 
   describe ".notify_compiled" do


### PR DESCRIPTION
#1 

The application should exit 1 when a test failed as any sane CLI tool should. This PR implements this functionality, and adds tests to ensure that it also exits 0 when no tests failed.

The design here should likely be rethought in the future, largely around the hash containing assertion results being passed between several methods. There's definitely a better way, but this is simple and will work for now.