### PR TITLE
Output file and line number of the failed assertion's subject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ rvm:
   - 2.0.0
   - 1.9.3
 script:
-  - bundle exec rake spec acceptance
+  - bundle exec rake spec
+  - bundle exec rake acceptance
   - bundle exec puppet module build
   - "cp pkg/*.tar.gz jordan-spec.tar.gz"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ rvm:
   - 2.0.0
   - 1.9.3
 script:
-  - bundle exec rake spec
-  - bundle exec rake acceptance
+  - bundle exec rake spec acceptance
   - bundle exec puppet module build
   - "cp pkg/*.tar.gz jordan-spec.tar.gz"
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
   result = `cd spec/acceptance; bundle exec puppet spec`
-  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 10 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
+  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 10 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
   unless result == expectation
     puts result.inspect
     raise "Check yoself, acceptance is failing."

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
   result = `cd spec/acceptance; bundle exec puppet spec`
-  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
+  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 10 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
   unless result == expectation
-    raise "Check yoself, acceptance is failing."
     puts result.inspect
+    raise "Check yoself, acceptance is failing."
   end
 end

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -74,7 +74,10 @@ class Puppet::Application::Spec < Puppet::Application
 
       unless assertion[:expectation] == assertion[:subject][assertion[:attribute]]
         failed_count += 1
-        msg = colorize(:red, "#{failed_count}) Assertion #{assertion[:name]} failed on #{assertion[:subject]}\n")
+        file = File.basename(assertion[:subject].file)
+
+        msg = colorize(:red, "#{failed_count}) Assertion #{assertion[:name]} failed on #{assertion[:subject].to_s}\n")
+        msg += colorize(:yellow, "   └ On line #{assertion[:subject].line} of #{file}\n")
         msg += colorize(:blue, "  Wanted: ")
         msg += "#{assertion[:attribute]} => '#{assertion[:expectation]}'\n"
         msg += colorize(:blue, "  Got:    ")

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -77,7 +77,7 @@ class Puppet::Application::Spec < Puppet::Application
         file = assertion[:subject].file.split('manifests/').last
 
         msg = colorize(:red, "#{failed_count}) Assertion #{assertion[:name]} failed on #{assertion[:subject].to_s}\n")
-        msg += colorize(:yellow, "   └ On line #{assertion[:subject].line} of #{file}\n")
+        msg += colorize(:yellow, "  On line #{assertion[:subject].line} of #{file}\n")
         msg += colorize(:blue, "  Wanted: ")
         msg += "#{assertion[:attribute]} => '#{assertion[:expectation]}'\n"
         msg += colorize(:blue, "  Got:    ")

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -74,7 +74,7 @@ class Puppet::Application::Spec < Puppet::Application
 
       unless assertion[:expectation] == assertion[:subject][assertion[:attribute]]
         failed_count += 1
-        file = File.basename(assertion[:subject].file)
+        file = assertion[:subject].file.split('manifests/').last
 
         msg = colorize(:red, "#{failed_count}) Assertion #{assertion[:name]} failed on #{assertion[:subject].to_s}\n")
         msg += colorize(:yellow, "   └ On line #{assertion[:subject].line} of #{file}\n")

--- a/spec/integration/puppet/application/spec_spec.rb
+++ b/spec/integration/puppet/application/spec_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Application::Spec do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 1,
           :failed => 1,
-          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 123 of stub file\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n"
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 123 of stub file\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
         })
       end
     end
@@ -52,7 +52,7 @@ describe Puppet::Application::Spec do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 1,
           :failed => 1,
-          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 12 of stub file again\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 12 of stub file again\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
         })
       end
     end

--- a/spec/integration/puppet/application/spec_spec.rb
+++ b/spec/integration/puppet/application/spec_spec.rb
@@ -16,11 +16,16 @@ describe Puppet::Application::Spec do
         )
       ]}
 
+      before do
+        the_assertions[0][:subject].file = 'stub file'
+        the_assertions[0][:subject].line = 123
+      end
+
       it "should return the expected output" do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 1,
           :failed => 1,
-          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 123 of stub file\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n"
         })
       end
     end
@@ -38,11 +43,16 @@ describe Puppet::Application::Spec do
         )
       ]}
 
+      before do
+        the_assertions[0][:subject].file = 'stub file again'
+        the_assertions[0][:subject].line = 12
+      end
+
       it "should return the expected output" do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 1,
           :failed => 1,
-          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
+          :msg    => "\e[0;31m1) Assertion stub assertion 1 failed on File[/tmp/test]\n\e[0m\e[0;33m   └ On line 12 of stub file again\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'present'\n\e[0;34m  Got:    \e[0mcontent => ''\n\n",
         })
       end
     end

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -258,29 +258,31 @@ describe Puppet::Application::Spec do
     end
 
     context "when given one passing and one failing assertion" do
+      let(:the_subject1) { stub(:file => 'stub file 1', :line => 'stub line 1', :to_s => 'stb2') }
+      let(:the_subject2) { stub(:file => 'stub file 2', :line => 'stub line 2', :to_s => 'stb1') }
       let(:the_assertions) {[
         {
           :expectation => 'stub_expectation_1',
           :attribute   => 'stub_attribute_1',
           :name        => 'stub_name_1',
-          :subject     => {
-            'stub_attribute_1' => 'stub_expectation_1',
-          },
+          :subject     => the_subject1
         },
         {
           :expectation => 'stub_expectation_2',
           :attribute   => 'stub_attribute_2',
           :name        => 'stub_name_2',
-          :subject     => {
-            'stub_attribute_2' => 'not the expectation',
-          },
+          :subject     => the_subject2
         }
       ]}
+      before do
+        the_subject1.stubs(:[]).with('stub_attribute_1').returns('the stub_attribute_1 value')
+        the_subject2.stubs(:[]).with('stub_attribute_2').returns('not the stub_attribute_2 value')
+      end
       it "should return the expected output" do
         expect(subject.visit_assertions(the_assertions)).to eq({
-          :count => 2,
-          :failed => 1,
-          :msg => "\e[0;31m1) Assertion stub_name_2 failed on {\"stub_attribute_2\"=>\"not the expectation\"}\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the expectation'\n\n",
+          :count  => 2,
+          :failed => 2,
+          :msg    => "\e[0;31m1) Assertion stub_name_1 failed on stb2\n\e[0m\e[0;33m   └ On line stub line 1 of stub file 1\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_1 => 'stub_expectation_1'\n\e[0;34m  Got:    \e[0mstub_attribute_1 => 'the stub_attribute_1 value'\n\n\e[0;31m2) Assertion stub_name_2 failed on stb1\n\e[0m\e[0;33m   └ On line stub line 2 of stub file 2\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the stub_attribute_2 value'\n\n",
         })
       end
     end

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -282,7 +282,7 @@ describe Puppet::Application::Spec do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 2,
           :failed => 2,
-          :msg    => "\e[0;31m1) Assertion stub_name_1 failed on stb2\n\e[0m\e[0;33m   └ On line stub line 1 of stub/1\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_1 => 'stub_expectation_1'\n\e[0;34m  Got:    \e[0mstub_attribute_1 => 'the stub_attribute_1 value'\n\n\e[0;31m2) Assertion stub_name_2 failed on stb1\n\e[0m\e[0;33m   └ On line stub line 2 of stub/2\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the stub_attribute_2 value'\n\n",
+          :msg    => "\e[0;31m1) Assertion stub_name_1 failed on stb2\n\e[0m\e[0;33m  On line stub line 1 of stub/1\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_1 => 'stub_expectation_1'\n\e[0;34m  Got:    \e[0mstub_attribute_1 => 'the stub_attribute_1 value'\n\n\e[0;31m2) Assertion stub_name_2 failed on stb1\n\e[0m\e[0;33m  On line stub line 2 of stub/2\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the stub_attribute_2 value'\n\n",
         })
       end
     end

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -258,9 +258,9 @@ describe Puppet::Application::Spec do
     end
 
     context "when given one passing and one failing assertion" do
-      let(:the_subject1) { stub(:file => 'stub file 1', :line => 'stub line 1', :to_s => 'stb2') }
-      let(:the_subject2) { stub(:file => 'stub file 2', :line => 'stub line 2', :to_s => 'stb1') }
-      let(:the_assertions) {[
+      let(:the_subject1){ stub(:file => 'manifests/stub/1', :line => 'stub line 1', :to_s => 'stb2') }
+      let(:the_subject2){ stub(:file => 'manifests/stub/2', :line => 'stub line 2', :to_s => 'stb1') }
+      let(:the_assertions){[
         {
           :expectation => 'stub_expectation_1',
           :attribute   => 'stub_attribute_1',
@@ -282,7 +282,7 @@ describe Puppet::Application::Spec do
         expect(subject.visit_assertions(the_assertions)).to eq({
           :count  => 2,
           :failed => 2,
-          :msg    => "\e[0;31m1) Assertion stub_name_1 failed on stb2\n\e[0m\e[0;33m   └ On line stub line 1 of stub file 1\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_1 => 'stub_expectation_1'\n\e[0;34m  Got:    \e[0mstub_attribute_1 => 'the stub_attribute_1 value'\n\n\e[0;31m2) Assertion stub_name_2 failed on stb1\n\e[0m\e[0;33m   └ On line stub line 2 of stub file 2\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the stub_attribute_2 value'\n\n",
+          :msg    => "\e[0;31m1) Assertion stub_name_1 failed on stb2\n\e[0m\e[0;33m   └ On line stub line 1 of stub/1\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_1 => 'stub_expectation_1'\n\e[0;34m  Got:    \e[0mstub_attribute_1 => 'the stub_attribute_1 value'\n\n\e[0;31m2) Assertion stub_name_2 failed on stb1\n\e[0m\e[0;33m   └ On line stub line 2 of stub/2\n\e[0m\e[0;34m  Wanted: \e[0mstub_attribute_2 => 'stub_expectation_2'\n\e[0;34m  Got:    \e[0mstub_attribute_2 => 'not the stub_attribute_2 value'\n\n",
         })
       end
     end


### PR DESCRIPTION
This PR implements enhancement #2. Failed assertion output now includes the subject's line number and file name.