### PR TITLE
Add Gem / Rake tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,37 @@
 language: ruby
 env:
-  - PUPPET_VERSION=4.2.1
-  - PUPPET_VERSION=4.2.0
-  - PUPPET_VERSION=4.1.0
-  - PUPPET_VERSION=4.0.0
+- PUPPET_VERSION=4.2.1
+- PUPPET_VERSION=4.2.0
+- PUPPET_VERSION=4.1.0
+- PUPPET_VERSION=4.0.0
 rvm:
-  - 2.2.0
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+- 2.2.0
+- 2.1.0
+- 2.0.0
+- 1.9.3
 script:
-  - bundle exec rake spec
-  - bundle exec rake acceptance
-  - bundle exec puppet module build
-  - "cp pkg/*.tar.gz jordan-spec.tar.gz"
-
+- bundle exec rake spec
+- bundle exec rake acceptance
+- bundle exec puppet module build
+- bundle exec gem build .gemspec
+- cp pkg/*.tar.gz jordan-spec.tar.gz
 deploy:
-  provider: releases
+  - provider: releases
   skip_cleanup: true
   file: jordan-spec.tar.gz
   on:
-    repo: jolshevski/puppet-spec
     tags: true
+    repo: jolshevski/puppet-spec
+    branch: master
   api_key:
     secure: J9M66JNkANXCZ52bG07KMSQvI6S1HnQh1D39eI70MkLmdJ1xfaBK80jcf8wJklv4c2ZBsnI5/JRpUITiRh9r/di9v0BXIbDEYDHQV27u5BpU/0NV3KzFFi2j/PZnY1rY4k3NczoHRAAqlK+oAZtgZZZrtAX8mpDg4sGpw7QXkOEbnvTbNErk05Rg0mb68aONrhjLQLVeERXS6Ij2KF6hl6rzxPCfUjTdUiKv+bCBZb4UUkaTv/vntBYoRA/E6MDKxhpF6vuoZhx8qZe/Xnsn0MfjEs2ojbuLeHgpvz2xc8dUplCeNcIk/2JQ/hRCZyVsZjbC0sxYUjw3GeoGjeopYzhV0YIfMsb7pvxrD6ZMx//HnRH+6YtSoUqZIfXTJfRIuwsWAhbAsjNm4pnJheRFjDCLId52MTDUvwQVjCKaNX2EXdQyIT71mn/JHzJLfO/hbixaikg1OvHtty2rAOLym/7LuNWmgvtitKCAldbwgETc5yPOZNnhMiSfsIkX3JpzQ8Xo7gIN18IhBTKaDCoU6MerCIUYRzxuN8fZifTISgrkf5QA6wUXDL8D/nMnzD/KWGO3D0d/adoKpeEp2cSaSohv7p0e5ines6svnWIxWJu6wrSk0LUC8d9wJP46Pb6LnPieFGBNJF7nI1IyxUORz3L7oYXyOCDXD20vvNz93Q0=
+  - provider: rubygems
+  skip_cleanup: true
+  gem: puppet-spec
+  gemspec: .gemspec
+  on:
+    tags: true
+    repo: jolshevski/puppet-spec
+    branch: master
+  api_key:
+    secure: cEPat4fEsy7U48U7XXgZhJYoVVt/0r5N3eyGvrcvLPryCmtDAQdrfEH/2F8H1xT4TJEh3RNZs3caOAjNDZMD/IJ6gBeFnUi/8pR9p1qfuOc+XZaNVE07e6xuMPLaFxkKaIx1iUDvDmodeTGLtt3PuQismdDd1BjoBpunzRQbbaDfxPq0tz8TQWRGuQYcQ0xiwPfkNidHrMaUumU8nLcLcNljqQ9kEm1aQ/ZOli6nnneknZ3Yign7l9UcfSOkpDFIGSdpnIHpzWcBYaMLgvExaTFwMBrYkG6Fcr9f+4TKTYBP7f3Iq4hJMwUiPY17sdKXrZwgLB7bWsZCrzo36/u+Pewuo01Y3pZ9ZnFUgiSfDQFgg7bfXX6jPlZVwOom3Dri0QOdPvbbRQFYnye/i7GQZzeqjIYVbki+hhCjN9e6BTtTqrRTDGQ/6jirEJY6G6Vge8lnzUR0b3TPygJzvu4mwuxfpBRwRB7dEqR5vMtLuCazFfGTRnctElsxA0LdbuekjkRkyzKi6vxY6nMiCv4zjQioxm1oxhSQG+4elSBHFV6E8IqaqsZow6WZvYpuTI0m6GzALOkbrb/rrKrgPYIMxAYraY/9kpY0VF9sk0cgzO1rNtghyr5ly+tUpfSskiil5Bn2BdrWMymfknDe0GxL3q/ZOoLoOHn+1e8aunTPtOE=

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
-  result = `cd spec/acceptance; bundle exec puppet spec`
+  result = `cd spec/acceptance; bundle exec rake puppetspec`
   expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 10 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
   unless result == expectation
     puts result.inspect

--- a/lib/puppet-spec/tasks.rb
+++ b/lib/puppet-spec/tasks.rb
@@ -1,0 +1,6 @@
+require 'puppet/application/spec'
+
+desc "Evaluate puppet-spec test cases and print the results"
+task(:puppetspec) do
+  Puppet::Application::Spec.new.run
+end

--- a/spec/acceptance/Rakefile
+++ b/spec/acceptance/Rakefile
@@ -1,0 +1,1 @@
+require 'puppet-spec/tasks'


### PR DESCRIPTION
#12 

Add autopublishing of the module as a rubygem, and a rake task to invoke Puppetspec. This will allow Puppetspec to be included as a Gem dependency of a Puppet module, 