### PR TITLE
CLI option for specifying single spec manifest

### DIFF
--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -6,12 +6,18 @@ require 'fileutils'
 class Puppet::Application::Spec < Puppet::Application
   include Puppet::Util::Colors
 
+  option("--manifest manifest",  "-m manifest")
+
   def run_command
     output = Hash.new
 
     begin
       Puppet::Test::TestHelper.initialize
-      output = process_spec_directory(specdir)
+      if options[:manifest]
+        output = process_spec(options[:manifest])
+      else
+        output = process_spec_directory(specdir)
+      end
     rescue Exception => e
       print colorize(:red, "#{e.message}\n")
       exit 1

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -3,12 +3,20 @@ require 'puppet/application/spec'
 
 describe Puppet::Application::Spec do
 
+  describe ".handle_manifest" do
+    it "should set the manifest configuration" do
+      subject.handle_manifest(:stub_manifest)
+      expect(subject.options[:manifest]).to eq(:stub_manifest)
+    end
+  end
+
   describe ".run_command" do
     let(:the_results) {{ :failed => 0 }}
 
     before do
       Puppet::Test::TestHelper.stubs(:initialize)
       subject.stubs(:process_spec_directory).returns(the_results)
+      subject.stubs(:process_spec).returns(the_results)
       subject.stubs(:print)
       subject.stubs(:exit)
       subject.stubs(:specdir).returns(:stub_specdir)
@@ -19,9 +27,21 @@ describe Puppet::Application::Spec do
       subject.run_command
     end
 
-    it "should process the spec directory" do
-      subject.expects(:process_spec_directory).with(:stub_specdir).returns(the_results)
-      subject.run_command
+    context "when the manifest has not been configured" do
+      it "should process the spec directory" do
+        subject.expects(:process_spec_directory).with(:stub_specdir).returns(the_results)
+        subject.run_command
+      end
+    end
+
+    context "when the manifest been configured" do
+      before { subject.send(:handle_manifest, :stub_manifest) }
+
+      it "should not process the spec directory" do
+        puts subject.options
+        subject.expects(:process_spec).with(:stub_manifest).returns(the_results)
+        subject.run_command
+      end
     end
 
     context "when an error is not raised" do


### PR DESCRIPTION
Issue #5 

This commit adds a CLI option that allows users to specify a single
manifest to be evaluated, instead of globing the ./spec directory.