### PR TITLE
Allow stubbed classes to receive arbitrary parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For examples, check out the acceptance test suite.
 Stub_facts takes a hash of fact/value pairs, and... stubs them. Technically it just defines top scope variables, but stub_top_scope_variables() doesn't quite roll off the tongue.
 
 #### stub_class('')
-Stub_class stubs a given class. It will accept no params (it's on the way, PR maybe?), and contains no resources. Classes can be namespaced as expected with the scope indicator.
+Stub_class stubs a given class. The stubbed class will accept values for any param. Classes can be namespaced as expected with the scope indicator.
 
 #### stub_type('')
 Stub_type stubs a defined type. Any parameters will be accepted and can be asserted upon. Like the stub_class function, the type name can be namespaced as you would expect.

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
   result = `cd spec/acceptance; bundle exec rake puppetspec`
-  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 10 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 5 assertions\n\e[0m"
+  expectation = "\e[0;32m.\e[0m\n\n\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\n\e[0m\e[0;33m  On line 13 of init.pp\n\e[0m\e[0;34m  Wanted: \e[0mcontent => 'not the contents'\n\e[0;34m  Got:    \e[0mcontent => 'the contents'\n\n\e[0;33mEvaluated 6 assertions\n\e[0m"
   unless result == expectation
     puts result.inspect
     raise "Check yoself, acceptance is failing."

--- a/lib/puppet/parser/functions/stub_class.rb
+++ b/lib/puppet/parser/functions/stub_class.rb
@@ -1,7 +1,9 @@
+require 'puppet/util/stubs'
+
 Puppet::Parser::Functions.newfunction(:stub_class, :arity => 1) do |values|
 
   raise Puppet::Error, "stub_class accepts a class name in the form of a string" unless values[0].is_a?(String)
 
-  compiler.environment.known_resource_types << Puppet::Resource::Type.new(:hostclass, values[0])
+  compiler.environment.known_resource_types << Puppet::Util::Stubs::Type.new(:hostclass, values[0])
 
 end

--- a/lib/puppet/parser/functions/stub_type.rb
+++ b/lib/puppet/parser/functions/stub_type.rb
@@ -1,15 +1,9 @@
-class Puppet::Resource::Type::Stub < Puppet::Resource::Type
-  # Allow the stub type to receive
-  # assignments on any parameter key.
-  def valid_parameter?(name)
-    true
-  end
-end
+require 'puppet/util/stubs'
 
 Puppet::Parser::Functions.newfunction(:stub_type, :arity => 1) do |values|
 
   raise Puppet::Error, "stub_type accepts a type name in the form of a string" unless values[0].is_a?(String)
 
-  compiler.environment.known_resource_types << Puppet::Resource::Type::Stub.new(:definition, values[0])
+  compiler.environment.known_resource_types << Puppet::Util::Stubs::Type.new(:definition, values[0])
 
 end

--- a/lib/puppet/util/stubs.rb
+++ b/lib/puppet/util/stubs.rb
@@ -1,0 +1,14 @@
+require 'puppet/resource/type'
+
+module Puppet::Util::Stubs
+
+  # This type reimplements the Puppet::Resource::Type class
+  # and overwrites the parameter validation in order to
+  # allow any param to be assigned a value.
+  class Type < Puppet::Resource::Type
+    def valid_parameter?(name)
+      true
+    end
+  end
+
+end

--- a/spec/acceptance/manifests/init.pp
+++ b/spec/acceptance/manifests/init.pp
@@ -1,6 +1,9 @@
 class acceptance {
 
-  include another::class
+  class { 'another::class':
+    param        => "value",
+    lkjsdflkjsdf => "123",
+  }
 
   package { 'the package':
     ensure   => $another,

--- a/spec/acceptance/spec/init_spec.pp
+++ b/spec/acceptance/spec/init_spec.pp
@@ -31,6 +31,12 @@ assertion { 'the class containing all the other stuff should be included':
   subject => Class['another::class'],
 }
 
+assertion { 'the class should have a gibberish attribute':
+  subject     => Class['another::class'],
+  attribute   => 'lkjsdflkjsdf',
+  expectation => '123',
+}
+
 assertion { 'the other thing is around':
   subject     => Another::Type['the other thing'],
   attribute   => 'ensure',

--- a/spec/unit/puppet/parser/functions/stub_type_spec.rb
+++ b/spec/unit/puppet/parser/functions/stub_type_spec.rb
@@ -10,7 +10,7 @@ describe "the stub_type function" do
 
   before do
     the_compiler.stubs(:environment).returns(the_environment)
-    Puppet::Resource::Type::Stub.stubs(:new).returns(:stub_type)
+    Puppet::Util::Stubs::Type.stubs(:new).returns(:stub_type)
   end
 
   context "when given a hash" do
@@ -23,24 +23,13 @@ describe "the stub_type function" do
 
   context "when given string" do
     it "should instantiate a stub type" do
-      Puppet::Resource::Type::Stub.expects(:new).with(:definition, "stub type name")
+      Puppet::Util::Stubs::Type.expects(:new).with(:definition, "stub type name")
       the_scope.function_stub_type(["stub type name"])
     end
 
     it "should append the type stub to the environment's known resource types" do
       the_resource_types.expects(:<<).with(:stub_type)
       the_scope.function_stub_type(["stub class name"])
-    end
-  end
-
-end
-
-describe Puppet::Resource::Type::Stub do
-  subject { Puppet::Resource::Type::Stub.new(:definition, 'stub resource') }
-
-  describe ".valid_parameter?" do
-    it "should return true" do
-      expect(subject.valid_parameter?('anything')).to be true
     end
   end
 

--- a/spec/unit/puppet/util/stubs_spec.rb
+++ b/spec/unit/puppet/util/stubs_spec.rb
@@ -1,0 +1,12 @@
+require 'puppet/util/stubs'
+
+describe Puppet::Util::Stubs::Type do
+  subject { Puppet::Util::Stubs::Type.new(:definition, 'stub resource') }
+
+  describe ".valid_parameter?" do
+    it "should return true" do
+      expect(subject.valid_parameter?('anything')).to be true
+    end
+  end
+
+end


### PR DESCRIPTION
#6 

This change fixes a bug (or rather a minor design flaw), in which the stubbed classes did not allow assignment of any parameters, deeming them useless for most applications. The PR moves the stub_type function's stubbed type class to the util namespace, and consumes it from the stub_class function.