### PR TITLE
Move assertion input validation to the type

### DIFF
--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -118,7 +118,6 @@ class Puppet::Application::Spec < Puppet::Application
   # a subject, or if it contains a
   # expectation without attribute.
   def validate_assertion(assertion)
-    raise Puppet::Error, "#{assertion} requires an attribute when an expectation is given" if assertion[:expectation] and not assertion[:attribute]
   end
 
   # Print an rspec style dot

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -118,7 +118,6 @@ class Puppet::Application::Spec < Puppet::Application
   # a subject, or if it contains a
   # expectation without attribute.
   def validate_assertion(assertion)
-    raise Puppet::Error, "#{assertion} requires a subject" unless assertion[:subject]
     raise Puppet::Error, "#{assertion} requires an attribute when an expectation is given" if assertion[:expectation] and not assertion[:attribute]
   end
 

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -76,7 +76,6 @@ class Puppet::Application::Spec < Puppet::Application
 
     msg = assertions.map do |assertion|
       count += 1
-      validate_assertion(assertion)
 
       unless assertion[:expectation] == assertion[:subject][assertion[:attribute]]
         failed_count += 1
@@ -111,13 +110,6 @@ class Puppet::Application::Spec < Puppet::Application
     else
       print colorize(:yellow, "Evaluated #{results[:count]} assertions\n")
     end
-  end
-
-  # Validate assertion raises an error
-  # if the assertion does not contain
-  # a subject, or if it contains a
-  # expectation without attribute.
-  def validate_assertion(assertion)
   end
 
   # Print an rspec style dot

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -6,6 +6,10 @@ Puppet::Type.newtype(:assertion) do
   spec application.
   "
 
+  validate do
+    fail Puppet::Error, "a subject is required" unless @parameters[:subject]
+  end
+
   newparam(:name) do
     desc "A plain text message describing what the assertion is intended to prove.
 

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -9,6 +9,7 @@ Puppet::Type.newtype(:assertion) do
   validate do
     fail Puppet::Error, "a subject is required" unless @parameters[:subject]
     fail Puppet::Error, "an attribute is required when an expectation is given" if @parameters[:expectation] and not @parameters[:attribute]
+    fail Puppet::Error, "an expectation is required when an attribute is given" if @parameters[:attribute] and not @parameters[:expectation]
   end
 
   newparam(:name) do

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -8,6 +8,7 @@ Puppet::Type.newtype(:assertion) do
 
   validate do
     fail Puppet::Error, "a subject is required" unless @parameters[:subject]
+    fail Puppet::Error, "an attribute is required when an expectation is given" if @parameters[:expectation] and not @parameters[:attribute]
   end
 
   newparam(:name) do

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -21,7 +21,7 @@ Puppet::Type.newtype(:assertion) do
     "
 
     validate do |value|
-      fail Puppet::Error, "Attributes must be a resource reference" unless value.is_a? Puppet::Resource
+      fail Puppet::Error, "Subject must be a resource reference" unless value.is_a? Puppet::Resource
     end
   end
 

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -21,17 +21,12 @@ Puppet::Type.newtype(:assertion) do
     "
 
     validate do |value|
-      fail Puppet::Error, "You must provide an assertion subject" unless value
       fail Puppet::Error, "Attributes must be a resource reference" unless value.is_a? Puppet::Resource
     end
   end
 
   newparam(:attribute) do
     desc "An attribute of the subject resource to assert against"
-
-    validate do |value|
-      fail Puppet::Error, "You must provide attribute to be asserted" unless value
-    end
   end
 
   newparam(:expectation) do

--- a/spec/integration/puppet/application/spec_spec.rb
+++ b/spec/integration/puppet/application/spec_spec.rb
@@ -87,7 +87,7 @@ describe Puppet::Application::Spec do
 
       it "should raise an error" do
         expect{subject.visit_assertions(the_assertions)}.to raise_error(
-          'Assertion[stub assertion 1] requires an attribute when an expectation is given'
+          'Validation of Assertion[stub assertion 1] failed: an attribute is required when an expectation is given'
         )
       end
     end

--- a/spec/integration/puppet/application/spec_spec.rb
+++ b/spec/integration/puppet/application/spec_spec.rb
@@ -68,7 +68,7 @@ describe Puppet::Application::Spec do
 
       it "should raise an error" do
         expect{subject.visit_assertions(the_assertions)}.to raise_error(
-          'Assertion[stub assertion 1] requires a subject'
+          'Validation of Assertion[stub assertion 1] failed: a subject is required'
         )
       end
     end

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -222,7 +222,6 @@ describe Puppet::Application::Spec do
 
   describe ".visit_assertions" do
     before do
-      subject.stubs(:validate_assertion)
     end
 
     context "when given one passing assertion" do
@@ -271,10 +270,6 @@ describe Puppet::Application::Spec do
           :msg    => "",
         })
       end
-      it "should validate each assertion" do
-        subject.expects(:validate_assertion).with(the_assertions[0])
-        subject.visit_assertions(the_assertions)
-      end
     end
 
     context "when given one passing and one failing assertion" do
@@ -306,9 +301,6 @@ describe Puppet::Application::Spec do
         })
       end
     end
-  end
-
-  describe ".validate_assertion" do
   end
 
   describe ".print_results" do

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -309,23 +309,6 @@ describe Puppet::Application::Spec do
   end
 
   describe ".validate_assertion" do
-    context "when given a subject, expectation, and no attribute" do
-      let(:the_assertion) { {:subject => true, :expectation => true, :attribute => nil} }
-
-      it "should raise an error" do
-        expect{subject.validate_assertion(the_assertion)}.to raise_error(
-          '{:subject=>true, :expectation=>true, :attribute=>nil} requires an attribute when an expectation is given'
-        )
-      end
-    end
-
-    context "when given a subject, expectation, and attribute" do
-      let(:the_assertion) { {:subject => true, :expectation => true, :attribute => true } }
-
-      it "should raise an error" do
-        expect{subject.validate_assertion(the_assertion)}.to_not raise_error
-      end
-    end
   end
 
   describe ".print_results" do

--- a/spec/unit/puppet/application/spec_spec.rb
+++ b/spec/unit/puppet/application/spec_spec.rb
@@ -309,16 +309,6 @@ describe Puppet::Application::Spec do
   end
 
   describe ".validate_assertion" do
-    context "when not given a subject" do
-      let(:the_assertion) { {:subject => nil} }
-
-      it "should raise an error" do
-        expect{subject.validate_assertion(the_assertion)}.to raise_error(
-          '{:subject=>nil} requires a subject'
-        )
-      end
-    end
-
     context "when given a subject, expectation, and no attribute" do
       let(:the_assertion) { {:subject => true, :expectation => true, :attribute => nil} }
 

--- a/spec/unit/puppet/type/assertion_spec.rb
+++ b/spec/unit/puppet/type/assertion_spec.rb
@@ -33,6 +33,22 @@ describe Puppet::Type.type(:assertion) do
         )
       end
     end
+
+    context "when given an expectation and no attribute" do
+      subject do
+        Puppet::Type.type(:assertion).new(
+          :name        => :stub_name,
+          :expectation => :stub_expectation,
+          :subject     => Puppet::Resource.new(:stub_type, :stub_subject),
+        )
+      end
+
+      it "should raise an error" do
+        expect{subject.validate}.to raise_error(
+          'Validation of Assertion[stub_name] failed: an attribute is required when an expectation is given'
+        )
+      end
+    end
   end
 end
 

--- a/spec/unit/puppet/type/assertion_spec.rb
+++ b/spec/unit/puppet/type/assertion_spec.rb
@@ -1,6 +1,41 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'puppet/type/assertion'
 
+describe Puppet::Type.type(:assertion) do
+  describe "validate" do
+    context "when given a attribute, expectation, and subject" do
+      subject do
+        Puppet::Type.type(:assertion).new(
+          :name        => :stub_name,
+          :attribute   => :stub_attribute,
+          :expectation => :stub_expectation,
+          :subject     => Puppet::Resource.new(:stub_type, :stub_subject),
+        )
+      end
+
+      it "should not raise an error" do
+        expect{subject.validate}.to_not raise_error
+      end
+    end
+
+    context "when given a attribute and expectation" do
+      subject do
+        Puppet::Type.type(:assertion).new(
+          :name        => :stub_name,
+          :attribute   => :stub_attribute,
+          :expectation => :stub_expectation,
+        )
+      end
+
+      it "should raise an error" do
+        expect{subject.validate}.to raise_error(
+          'Validation of Assertion[stub_name] failed: a subject is required'
+        )
+      end
+    end
+  end
+end
+
 describe Puppet::Type::Assertion::ParameterSubject do
   let(:the_resource) { stub }
   subject { Puppet::Type::Assertion::ParameterSubject.new(:resource => the_resource) }

--- a/spec/unit/puppet/type/assertion_spec.rb
+++ b/spec/unit/puppet/type/assertion_spec.rb
@@ -1,50 +1,22 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
 require 'puppet/type/assertion'
 
-describe Puppet::Type::Assertion::ParameterAttribute do
-  let(:the_resource) { stub }
-  let(:the_subject) { stub }
-  subject { Puppet::Type::Assertion::ParameterAttribute.new(:resource => the_resource) }
-
-  describe ".validate" do
-    before do
-      the_resource.stubs(:[]).returns(the_subject)
-    end
-
-    context "when not given a value" do
-      it "should raise an error" do
-        expect{subject.validate(nil)}.to raise_error(
-          'You must provide attribute to be asserted'
-        )
-      end
-    end
-
-    context "when given a valid parameter" do
-      let(:the_subject) { stub(:valid_parameter? => true) }
-      it "should not raise an error" do
-        expect{subject.validate('stub attribute')}.to_not raise_error
-      end
-    end
-
-  end
-end
-
 describe Puppet::Type::Assertion::ParameterSubject do
   let(:the_resource) { stub }
   subject { Puppet::Type::Assertion::ParameterSubject.new(:resource => the_resource) }
 
   describe ".validate" do
-    context "when not given a value" do
+    context "when given a string" do
       it "should raise an error" do
-        expect{subject.validate(nil)}.to raise_error(
-          'You must provide an assertion subject'
+        expect{subject.validate('test')}.to raise_error(
+          'Attributes must be a resource reference'
         )
       end
     end
 
-    context "when given a string" do
+    context "when given a hash" do
       it "should raise an error" do
-        expect{subject.validate('test')}.to raise_error(
+        expect{subject.validate({:key => :value})}.to raise_error(
           'Attributes must be a resource reference'
         )
       end

--- a/spec/unit/puppet/type/assertion_spec.rb
+++ b/spec/unit/puppet/type/assertion_spec.rb
@@ -34,6 +34,22 @@ describe Puppet::Type.type(:assertion) do
       end
     end
 
+    context "when given an attribute and no expectation" do
+      subject do
+        Puppet::Type.type(:assertion).new(
+          :name        => :stub_name,
+          :attribute   => :stub_attribute,
+          :subject     => Puppet::Resource.new(:stub_type, :stub_subject),
+        )
+      end
+
+      it "should raise an error" do
+        expect{subject.validate}.to raise_error(
+          'Validation of Assertion[stub_name] failed: an expectation is required when an attribute is given'
+        )
+      end
+    end
+
     context "when given an expectation and no attribute" do
       subject do
         Puppet::Type.type(:assertion).new(

--- a/spec/unit/puppet/type/assertion_spec.rb
+++ b/spec/unit/puppet/type/assertion_spec.rb
@@ -9,7 +9,7 @@ describe Puppet::Type::Assertion::ParameterSubject do
     context "when given a string" do
       it "should raise an error" do
         expect{subject.validate('test')}.to raise_error(
-          'Attributes must be a resource reference'
+          'Subject must be a resource reference'
         )
       end
     end
@@ -17,7 +17,7 @@ describe Puppet::Type::Assertion::ParameterSubject do
     context "when given a hash" do
       it "should raise an error" do
         expect{subject.validate({:key => :value})}.to raise_error(
-          'Attributes must be a resource reference'
+          'Subject must be a resource reference'
         )
       end
     end


### PR DESCRIPTION
#17 

This change moves all validation of the declared parameters to the assertion resource type from the application. In the process, I also corrected a typo in the presentation and removed some unnecessary validation.