### PR TITLE
Improved handling of missing subject resource

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
   result = `cd spec/acceptance; bundle exec rake puppetspec`
-  expectation = "\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;33mEvaluated 6 assertions\e[0m\n"
+  expectation = "\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;31m2) Assertion the resource is in the catalog failed on File[/tmp/should/be/around]\e[0m\n\e[0;34m  Subject was not in the catalog\e[0m\n\n\e[0;33mEvaluated 6 assertions\e[0m\n"
   unless result == expectation
     puts result.inspect, expectation.inspect
     raise "Check yoself, acceptance is failing."

--- a/lib/puppet/application/spec.rb
+++ b/lib/puppet/application/spec.rb
@@ -38,15 +38,21 @@ class Puppet::Application::Spec < Puppet::Application
 
   def process_spec(path)
     catalog = catalog(path)
-    assertions = catalog.resources.select {|res| res.type == 'Assertion' }
 
+    assertions = catalog.resources.select {|res| res.type == 'Assertion' }
     assertions.each do |res|
       # Get the subject resource from the catalog rather than the
       # reference provided from the parser. The reference's resource
       # object does not contain any parameters for whatever reason.
-      res[:subject] = catalog.resource(res[:subject].to_s)
+      catalog_subject = catalog.resource(res[:subject].to_s)
 
-      reporter << res.to_ral
+      if catalog_subject
+        res[:subject] = catalog_subject
+        reporter << res.to_ral
+      else
+        reporter.missing_subject(res)
+      end
+
     end
   end
 

--- a/lib/puppet/util/assertion/reporter.rb
+++ b/lib/puppet/util/assertion/reporter.rb
@@ -47,6 +47,27 @@ module Puppet::Util
         end
       end
 
+      # Print the appropriate error message when an assertion's
+      # subject is not found in the catalog. Called by the application
+      # because the resource must be evaluated prior to calling
+      # .to_ral to avoid the validation raising an error.
+      def missing_subject(assertion)
+        fail
+
+        # Shim the value of failed into the
+        # local scope in order to access it
+        # from the style proc.
+        failed = @failed
+
+        style do
+          red      "#{failed}) Assertion #{assertion[:name]} failed on #{assertion[:subject].to_s}"
+          newline
+          blue     "  Subject was not in the catalog"
+          newline
+          newline
+        end
+      end
+
       # Pretty print the results of an assertion to the console
       def report(assertion)
         # Shim the value of failed into the

--- a/spec/acceptance/spec/init_spec.pp
+++ b/spec/acceptance/spec/init_spec.pp
@@ -42,3 +42,7 @@ assertion { 'the other thing is around':
   attribute   => 'ensure',
   expectation => 'around',
 }
+
+assertion { 'the resource is in the catalog':
+  subject => File['/tmp/should/be/around'],
+}


### PR DESCRIPTION
#22

Previously, a missing subject resource caused a Puppet resource validation
error to be raised, halting the evaluation of the catalog, and printing
a single cryptic message. This commit implements better handling of
these events in the reporter.