### PR TITLE
Documentation Corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ file { '/tmp/test':
   content => 'The file content',
 }
 
-assertion { 'the file has the correct contents':
+assertion { 'that the file has the correct contents':
   subject     => File['/tmp/test'],
   attribute   => 'content',
   expectation => 'The file content',
 }
 
-assertion { 'the file is present':
+assertion { 'that the file is present':
   subject     => File['/tmp/test'],
   attribute   => 'ensure',
   expectation => 'present',
@@ -71,11 +71,11 @@ Okay. Puppet spec test cases are just manifests that happen to contain assertion
 ```puppet
 include apache
 
-assertion { 'the apache::ssl class is in the catalog':
+assertion { 'that the apache::ssl class is in the catalog':
   subject     => Class['apache::ssl'],
 }
 
-assertion { 'the apache package version is correct':
+assertion { 'that the apache package version is correct':
   subject     => Package['apache::package'],
   attribute   => 'ensure',
   expectation => '1.2.3',

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 
 task(:acceptance) do
   result = `cd spec/acceptance; bundle exec rake puppetspec`
-  expectation = "\e[0;31m1) Assertion the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;31m2) Assertion the resource is in the catalog failed on File[/tmp/should/be/around]\e[0m\n\e[0;34m  Subject was not in the catalog\e[0m\n\n\e[0;33mEvaluated 6 assertions\e[0m\n"
+  expectation = "\e[0;31m1) Assertion that the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;31m2) Assertion that the resource is in the catalog failed on File[/tmp/should/be/around]\e[0m\n\e[0;34m  Subject was not in the catalog\e[0m\n\n\e[0;33mEvaluated 6 assertions\e[0m\n"
   unless result == expectation
     puts result.inspect, expectation.inspect
     raise "Check yoself, acceptance is failing."

--- a/lib/puppet/type/assertion.rb
+++ b/lib/puppet/type/assertion.rb
@@ -1,10 +1,6 @@
 Puppet::Type.newtype(:assertion) do
 
-  @doc = "Makes assertions on the state of a resource in the catalog.
-
-  The assertion type defines an assertion that will be evaluated by the
-  spec application.
-  "
+  @doc = "An assertion on the state of a resource in the catalog"
 
   validate do
     fail Puppet::Error, "a subject is required" unless @parameters[:subject]
@@ -13,7 +9,7 @@ Puppet::Type.newtype(:assertion) do
   end
 
   newparam(:name) do
-    desc "A plain text message describing what the assertion is intended to prove.
+    desc "A plain text message describing what the assertion is attempting to prove.
 
     The given text should form a sentence using the type's name.
     Example: assertion { 'that the configuration file has the correct contents': }

--- a/spec/acceptance/spec/init_spec.pp
+++ b/spec/acceptance/spec/init_spec.pp
@@ -9,40 +9,40 @@ stub_type("another::type")
 
 include acceptance
 
-assertion { 'the package should be the correct version':
+assertion { 'that the package should be the correct version':
   subject     => Package['the package'],
   attribute   => 'ensure',
   expectation => '1.2.3',
 }
 
-assertion { 'the configuration file has the correct contents':
+assertion { 'that the configuration file has the correct contents':
   subject     => File['/tmp/test'],
   attribute   => 'content',
   expectation => 'not the contents',
 }
 
-assertion { 'the service should start on boot':
+assertion { 'that the service should start on boot':
   subject     => Service['the service'],
   attribute   => 'enable',
   expectation => true,
 }
 
-assertion { 'the class containing all the other stuff should be included':
+assertion { 'that the class containing all the other stuff should be included':
   subject => Class['another::class'],
 }
 
-assertion { 'the class should have a gibberish attribute':
+assertion { 'that the class should have a gibberish attribute':
   subject     => Class['another::class'],
   attribute   => 'lkjsdflkjsdf',
   expectation => '123',
 }
 
-assertion { 'the other thing is around':
+assertion { 'that the other thing is around':
   subject     => Another::Type['the other thing'],
   attribute   => 'ensure',
   expectation => 'around',
 }
 
-assertion { 'the resource is in the catalog':
+assertion { 'that the resource is in the catalog':
   subject => File['/tmp/should/be/around'],
 }


### PR DESCRIPTION
#4

The assertion resource examples in the README and acceptance test suite were missing the 'that' title prefix. This PR also clarifies the doc tags in the assertion resource type.