### PR TITLE
Adding Fixture Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Stub_class stubs a given class. The stubbed class will accept values for any par
 Stub_type stubs a defined type. Any parameters will be accepted and can be asserted upon. Like the stub_class function, the type name can be namespaced as you would expect.
 
 
+## Fixtures
+Asserting on attributes with a very long expectation can be unpleasant, so Puppet spec provides a `fixture` function which reads from a given file underneath `spec/fixtures`.
+
+### Example
+```puppet
+assertion { 'that the file has the correct very long contents':
+  subject     => File['/tmp/largefile'],
+  attribute   => 'content',
+  expectation => fixture('file_contents'), #This would load the file `<module>/spec/fixtures/file_contents`
+}
+```
+
+
 ## Want to pitch in?
 I wrote this tool because I felt that the community could use an approachable testing mechanism in Puppet's native tongue. If you feel the same, feel free to take on an open GH issue, or find a bug. If your changes have good tests (irony?), I'll merge and not yell at you even a little bit. If you're not up for the hacking, feel free to open an issue and I'll have a look.
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'puppetlabs_spec_helper/rake_tasks'
 task(:acceptance) do
   rake_result = `cd spec/acceptance; bundle exec rake puppetspec`
   cli_result = `cd spec/acceptance; bundle exec puppet spec`
-  expectation = "\e[0;31m1) Assertion that the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;31m2) Assertion that the resource is in the catalog failed on File[/tmp/should/be/around]\e[0m\n\e[0;34m  Subject was expected to be present in the catalog, but was absent\e[0m\n\n\e[0;33mEvaluated 8 assertions\e[0m\n"
+  expectation = "\e[0;31m1) Assertion that the configuration file has the correct contents failed on File[/tmp/test]\e[0m\n\e[0;33m  On line 13 of init.pp\e[0m\n\e[0;34m  Wanted: \e[0m{\"content\"=>\"not the contents\"}\n\e[0;34m  Got:    \e[0m{\"content\"=>\"the contents\"}\n\n\e[0;31m2) Assertion that the resource is in the catalog failed on File[/tmp/should/be/around]\e[0m\n\e[0;34m  Subject was expected to be present in the catalog, but was absent\e[0m\n\n\e[0;33mEvaluated 9 assertions\e[0m\n"
 
   unless rake_result == expectation
     puts rake_result.inspect, expectation.inspect

--- a/lib/puppet/parser/functions/fixture.rb
+++ b/lib/puppet/parser/functions/fixture.rb
@@ -1,3 +1,6 @@
-Puppet::Parser::Functions.newfunction(:fixture, :arity => 1) do |values|
+Puppet::Parser::Functions.newfunction(:fixture, :arity => 1, :type => :rvalue) do |values|
+  modulepath = compiler.environment.full_modulepath[0]
+  file = Dir.glob("#{modulepath}/*/spec/fixtures/#{values[0]}")[0]
 
+  return File.read(file)
 end

--- a/lib/puppet/parser/functions/fixture.rb
+++ b/lib/puppet/parser/functions/fixture.rb
@@ -1,0 +1,3 @@
+Puppet::Parser::Functions.newfunction(:fixture, :arity => 1) do |values|
+
+end

--- a/spec/acceptance/manifests/init.pp
+++ b/spec/acceptance/manifests/init.pp
@@ -24,4 +24,9 @@ class acceptance {
     ensure => 'around',
   }
 
+  file { '/tmp/test2':
+    ensure  => present,
+    content => "stub content\n",
+  }
+
 }

--- a/spec/acceptance/spec/fixtures/test2
+++ b/spec/acceptance/spec/fixtures/test2
@@ -1,0 +1,1 @@
+stub content

--- a/spec/acceptance/spec/init_spec.pp
+++ b/spec/acceptance/spec/init_spec.pp
@@ -51,3 +51,9 @@ assertion { 'that the undesired file is not in the catalog':
   ensure  => absent,
   subject => File['/tmp/should/not/be/around'],
 }
+
+assertion { 'that the other configuration file has the correct contents':
+  subject     => File['/tmp/test2'],
+  attribute   => 'content',
+  expectation => fixture('test2'),
+}

--- a/spec/integration/puppet/parser/functions/fixture_spec.rb
+++ b/spec/integration/puppet/parser/functions/fixture_spec.rb
@@ -1,0 +1,13 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+describe "the fixture function" do
+  let(:the_node)     { Puppet::Node.new('stub_node') }
+  let(:the_compiler) { Puppet::Parser::Compiler.new(the_node) }
+  let(:the_scope)    { Puppet::Parser::Scope.new(the_compiler) }
+
+  it "should load the fixture" do
+    File.expects(:read).returns(:stub_file)
+    expect(the_scope.function_fixture(["the fixture"])).to eq(:stub_file)
+  end
+
+end


### PR DESCRIPTION
This PR adds a new parser function which allows users to load expectations from disk. The behavior is intended to indirectly resolve issue #3.